### PR TITLE
Helm3 release action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,3 +53,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_RELEASE_NAME_TEMPLATE: spark-operator-chart-{{ -.Version }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,4 +53,4 @@ jobs:
         uses: helm/chart-releaser-action@v1.1.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          CR_RELEASE_NAME_TEMPLATE: spark-operator-chart-{{ -.Version }}"
+          CR_RELEASE_NAME_TEMPLATE: "spark-operator-chart-{{ -.Version }}"


### PR DESCRIPTION
Add Release name parameter to the Chart Releaser action to separate Travis CI release from Helm Chart.